### PR TITLE
Add defines to enable building on Windows

### DIFF
--- a/src/lisp.h
+++ b/src/lisp.h
@@ -35,6 +35,11 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#ifdef WIN32
+#include <algorithm>
+#include <cctype>
+#endif
+
 enum Lisp_Type
 {
 	lisp_type_list = 1 << 0,


### PR DESCRIPTION
Had to add the included headers to get a clean compile. Includes are guarded for use on windows only.