### PR TITLE
Correct define so it works for win64 bit build

### DIFF
--- a/src/lisp.h
+++ b/src/lisp.h
@@ -35,7 +35,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef WIN32
+#ifdef _WIN64
 #include <algorithm>
 #include <cctype>
 #endif


### PR DESCRIPTION
The define was incorrect for 64bit builds - this addresses that issue